### PR TITLE
Adding Farcaster Directory to list of tools.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
 - [Searchcaster](https://raycast.com/gregskril/searchcaster) - Raycast extension for search
 - [CastRSS](https://castrss.xyz) - Make user-specific RSS feeds.
 - [Fardrop](https://fardrop.xyz) - Create an allowlist based on followers.
+- [Farcaster Directory](https://directory.yashkarthik.xyz/) - A database mapping Twitter accounts to Farcaster accounts. Enabling users to establish a link between their Twitter accounts and their Farcaster account.
 
 ## Bots
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@
 - [Searchcaster](https://raycast.com/gregskril/searchcaster) - Raycast extension for search
 - [CastRSS](https://castrss.xyz) - Make user-specific RSS feeds.
 - [Fardrop](https://fardrop.xyz) - Create an allowlist based on followers.
-- [Farcaster Directory](https://directory.yashkarthik.xyz/) - A database mapping Twitter accounts to Farcaster accounts. Enabling users to establish a link between their Twitter accounts and their Farcaster account.
 
 ## Bots
 
@@ -52,6 +51,7 @@ These bots are available on Farcaster. You can mention them in a cast to get a r
 - [Farapps](https://farapps.farcase.xyz) - Showcase of apps.
   - Open source [here](https://github.com/farcase/farapps).
 - [Merkle Manufactory's Ecosystem Page](https://www.farcaster.xyz/ecosystem) - Clients, tools, and other links.
+- [Yash's Directory](https://directory.yashkarthik.xyz/) - Public mapping between Twitter and Farcaster accounts.
 
 ## Developer Resources
 


### PR DESCRIPTION
Added [Farcaster Directory](https://directory.yashkarthik.xyz) to list of tools.

It's a database that maps Twitter accounts to Farcaster accounts. Establishing a link between a user's Twitter and FC. Enabling ppl to find their twitter friends here.

Cheers!