### PR TITLE
Add farcaster-auth-tokens to repos section

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ These bots are available on Farcaster. You can mention them in a cast to get a r
 - [whatrocks/farcaster-feed](https://github.com/whatrocks/farcaster-feed)
   - Syndicates a user's casts via JS to another surface, like a static site.
 - [davidfurlong/farcaster-auth-tokens](https://github.com/davidfurlong/farcaster-auth-tokens)
-  - Scripts to create and revoke farcaster auth tokens
+  - Issue and revoke auth tokens
 
 ### Analytics and Data
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ These bots are available on Farcaster. You can mention them in a cast to get a r
   - Create a diagram that shows your Farcaster circle.
 - [whatrocks/farcaster-feed](https://github.com/whatrocks/farcaster-feed)
   - Syndicates a user's casts via JS to another surface, like a static site.
+- [davidfurlong/farcaster-auth-tokens](https://github.com/davidfurlong/farcaster-auth-tokens)
+  - Scripts to create and revoke farcaster auth tokens
 
 ### Analytics and Data
 


### PR DESCRIPTION
I just published an open source repo that makes it easier to create and revoke farcaster API auth tokens, and I think it makes sense to add it here.