### PR TITLE
Add Paragraph bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,6 @@ These bots are available on Farcaster. You can mention them in a cast to get a r
   - Open source at [alexpaden/ditti-bot](https://github.com/alexpaden/ditti-bot).
 - [@paragraph](https://fcast.me/paragraph) - Summarizes and casts about articles published on [Paragraph](https://paragraph.xyz).
 
-
 ### Community
 
 - [Citycaster](https://citycaster.xyz) - City-based Telegram groups.

--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ These bots are available on Farcaster. You can mention them in a cast to get a r
   - Open source at [benadamsky/surveycaster](https://github.com/benadamsky/surveycaster).
 - [@ditti](https://fcast.me/ditti) - A bot with multiple commands that mimicks the style of command line interface packages. Cast "@ditti help" for more information.
   - Open source at [alexpaden/ditti-bot](https://github.com/alexpaden/ditti-bot).
+- [@paragraph](https://fcast.me/paragraph) - Summarizes and casts about articles published on [Paragraph](https://paragraph.xyz).
+
 
 ### Community
 


### PR DESCRIPTION
I added the newly created Paragraph bot (https://warpcast.com/colin/0x3fb774).

I have an open question: Paragraph has a handful of other integrations with Farcaster:
- if you register on Paragraph, we pull in your Farcaster followers and prompt you to subscribe to them
- all discussion about a Paragraph article is pulled in and displayed directly on the post
- you can view all posts created by your Farcaster followers

More info about the integrations [here](https://paragraph.xyz/@blog/farcaster-comments) and [here](https://paragraph.xyz/@blog/discovery). 

I wasn't exactly sure if these belong here -- they don't exactly fit into the existing README (I'm not sure I'd consider Paragraph a Farcaster client, for example, but these integrations are popular on FC nonetheless). Thoughts?