### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@
 - [Searchcaster](https://raycast.com/gregskril/searchcaster) - Raycast extension for search
 - [CastRSS](https://castrss.xyz) - Make user-specific RSS feeds.
 - [Fardrop](https://fardrop.xyz) - Create an allowlist based on followers.
+- [XCaster](https://xcaster.xyz) - Turn your X into Farcaster.
+
 
 ## Bots
 


### PR DESCRIPTION
Add XCaster. A Chrome extension that enables you to share tweets with Farcaster friends