### PR TITLE
Adds Farcaster Kit

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ These bots are available on Farcaster. You can mention them in a cast to get a r
 - [Phrasetown's API Docs](https://productive-feet-714.notion.site/Phrasetown-API-Docs-80d46ed343c6453382e46fb58214263a)
   - The Phrasetown client has its own useful API.
  - [Wield Farcaster API Docs](https://docs.wield.co/farcaster/api)
-   - Free & Open-Source APIs for Farcaster.
+   - Free & open source APIs for Farcaster.
 - [Farcaster Kit Docs](https://farcasterkit.com/docs)
    - Free React hooks and API for Farcaster apps.
 
@@ -171,9 +171,9 @@ These bots are available on Farcaster. You can mention them in a cast to get a r
 - [fmhall/fc-bot-template](https://github.com/fmhall/fc-bot-template)
   - A template repository to quickly spin up a bot using the farcaster-py SDK
 - [ponder-surveys/farcaster-survey-bot](https://github.com/ponder-surveys/farcaster-survey-bot)
-  - An open-source NodeJS bot designed to post engaging surveys directly on Farcaster.
+  - An open source NodeJS bot designed to post engaging surveys directly on Farcaster.
 - [mod-protocol/mod](https://github.com/mod-protocol/mod)
-  - An open-source Editor for creating casts, rendering rich embeds and a protocol for Farcaster Mini-apps.
+  - An open source Editor for creating casts, rendering rich embeds and a protocol for Farcaster Mini-apps.
 
 ### Analytics and Data
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@
 - [Bountycaster](https://www.bountycaster.xyz/)
   - Create and complete bounties on Farcaster - [Web](https://www.bountycaster.xyz)
 - [33bits](https://33bits.xyz)
-  - Cast anonymously on Farcaster through Zero-Knowledge proofs
+  - Cast anonymously on Farcaster through Zero-Knowledge proofs - [Web](https://33bits.xyz)
 
 ## Tools
 

--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ These bots are available on Farcaster. You can mention them in a cast to get a r
   - The Phrasetown client has its own useful API.
  - [Wield Farcaster API Docs](https://docs.wield.co/farcaster/api)
    - Free & Open-Source APIs for Farcaster.
+- [Farcaster Kit Docs](https://farcasterkit.com/docs)
+   - Free React hooks and API for Farcaster apps.
 
 ### Services
 


### PR DESCRIPTION
Adds [Farcaster Kit](https://farcasterkit.com), free React hooks and an API for Farcaster apps, to the Developer Resources Documentation section.