### PR TITLE
Adds Litecast TestFlight and GH repo to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@
   - [Web](http://flink.fyi/)
 - [FarQuest](https://far.quest)
   - [Web](https://far.quest)
+- [Litecast](https://github.com/dylsteck/litecast)
+  - [TestFlight(iOS)](https://testflight.apple.com/join/qVTQkztU)
 
 ### Specialized
 


### PR DESCRIPTION
Adds my open source mobile client [Litecast](https://github.com/dylsteck/litecast) and its TestFlight/GitHub links to README.md