### PR TITLE
Add Farcaster Frame + Airstack API Resources 

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,10 @@ These bots are available on Farcaster. You can mention them in a cast to get a r
   - Various APIs and services for Farcaster.
 - [Airstack API Documentaion](https://docs.airstack.xyz)
   - Composable Web3 APIs to fetch and combine Farcaster and other onchain & off-chain data, e.g. ENS, Base, Zora, XMTP, Lens, etc.
+- [Airstack Activate Kit For Farcaster Auth Kit](https://docs.airstack.xyz/airstack-docs-and-faqs/guides/farcaster/activate-kit-for-farcaster-auth-kit)
+  - A series of API calls to activate Farcaster users after they connect with Farcaster Auth Kit
+- [Airstack Onchain Kit For Farcaster Frames](https://docs.airstack.xyz/airstack-docs-and-faqs/guides/farcaster/airstack-onchain-kit-for-farcaster-frames)
+  - Enrich Farcaster Frames with additional onchain data from Airstack APIs.
 - [farcasterxyz/protocol](https://github.com/farcasterxyz/protocol)
   - Farcaster protocol specification.
 - [farcasterxyz/hub](https://github.com/farcasterxyz/hub-monorepo)

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ These bots are available on Farcaster. You can mention them in a cast to get a r
 - [Neynar API Documentation](https://docs.neynar.com)
   - Various APIs and services for Farcaster.
 - [Airstack API Documentaion](https://docs.airstack.xyz)
-  - Composable Web3 APIs to fetch and combine Farcaster and other onchain & off-chain data, e.g. ENS, Base, Zora, XMTP, Lens, etc.
+  - Composable Web3 APIs to fetch and combine Farcaster and other onchain & off-chain data, e.g. ENS, Base, Zora, XMTP, etc.
 - [Airstack Activate Kit For Farcaster Auth Kit](https://docs.airstack.xyz/airstack-docs-and-faqs/guides/farcaster/activate-kit-for-farcaster-auth-kit)
   - A series of API calls to activate Farcaster users after they connect with Farcaster Auth Kit
 - [Airstack Onchain Kit For Farcaster Frames](https://docs.airstack.xyz/airstack-docs-and-faqs/guides/farcaster/airstack-onchain-kit-for-farcaster-frames)

--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ These bots are available on Farcaster. You can mention them in a cast to get a r
   - Warpcast's v2 API
 - [Neynar API Documentation](https://docs.neynar.com)
   - Various APIs and services for Farcaster.
+- [Airstack API Documentaion](https://docs.airstack.xyz)
+  - Composable Web3 APIs to fetch and combine Farcaster and other onchain & off-chain data, e.g. ENS, Base, Zora, XMTP, Lens, etc.
 - [farcasterxyz/protocol](https://github.com/farcasterxyz/protocol)
   - Farcaster protocol specification.
 - [farcasterxyz/hub](https://github.com/farcasterxyz/hub-monorepo)
@@ -139,6 +141,8 @@ These bots are available on Farcaster. You can mention them in a cast to get a r
 
 - [Neynar Hosted Hubs](https://hubs.neynar.com)
 - [Wield Free Farcaster APIs & Hub](https://docs.wield.co/farcaster/api)
+- [Airstack API Studio](https://app.airstack.xyz)
+- [Airstack Explorer](https://explorer.airstack.xyz)
 
 ### Repos
 

--- a/README.md
+++ b/README.md
@@ -126,8 +126,6 @@ These bots are available on Farcaster. You can mention them in a cast to get a r
   - Composable Web3 APIs to fetch and combine Farcaster and other onchain & off-chain data, e.g. ENS, Base, Zora, XMTP, etc.
 - [Airstack Activate Kit For Farcaster Auth Kit](https://docs.airstack.xyz/airstack-docs-and-faqs/guides/farcaster/activate-kit-for-farcaster-auth-kit)
   - A series of API calls to activate Farcaster users after they connect with Farcaster Auth Kit
-- [Airstack Onchain Kit For Farcaster Frames](https://docs.airstack.xyz/airstack-docs-and-faqs/guides/farcaster/airstack-onchain-kit-for-farcaster-frames)
-  - Enrich Farcaster Frames with additional onchain data from Airstack APIs.
 - [farcasterxyz/protocol](https://github.com/farcasterxyz/protocol)
   - Farcaster protocol specification.
 - [farcasterxyz/hub](https://github.com/farcasterxyz/hub-monorepo)
@@ -201,6 +199,11 @@ These bots are available on Farcaster. You can mention them in a cast to get a r
 - [SQLCaster](https://sqlcaster.xyz) - Query with SQL.
   - Open source [here](https://github.com/shrimalmadhur/trendcaster).
 - [Farcaster Insights](https://data.hubs.neynar.com/public/dashboards/U6aGGq6CQOZXIx6IO71NbaUFDMwX14nYs0OyhT88) - Network dashboard.
+
+### Farcaster Frames
+
+- [Airstack Onchain Kit For Farcaster Frames](https://docs.airstack.xyz/airstack-docs-and-faqs/guides/farcaster/airstack-onchain-kit-for-farcaster-frames)
+  - Enrich Farcaster Frames with additional onchain data from Airstack APIs.
 
 ## Contributions
 


### PR DESCRIPTION
Added some relevant Farcaster resources from Airstack:
- Airstack API docs
- Airstack Activate Kit for Farcaster Auth Kit
- Airstack API Studio (App)
- Airstack Explorer (Demo)

Also created new `Farcaster Frames` Section under `Developer Resources` and added:
- Airstack Onchain Kit for Farcaster Frames