### PR TITLE
Removed casterscan & castalytics as they stopped working

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,12 +183,9 @@ These bots are available on Farcaster. You can mention them in a cast to get a r
 
 ### Analytics and Data
 
-- [Castalytics](https://castalytics.farcase.xyz) - User analytics.
 - [Farcaster User Stats](https://www.farcasteruserstats.com/) - User analytics. - [GitHub](https://github.com/mattwelter/farcaster-user-stats)
 - [Trendcaster](https://www.trendcaster.xyz) - Personal analytics.
 - [Farcaster Network](https://farcaster.network) - Network dashboard.
-- [Casterscan](https://casterscan.com) - A block explorer for Farcaster.
-  - Open source [here](https://github.com/dylsteck/casterscan).
 - [Goerli Subgraph](https://thegraph.com/hosted-service/subgraph/0xsarvesh/farcaster-goerli) - Farcaster data on Ethereum's Goerli testnet.
 - [SQLCaster](https://sqlcaster.xyz) - Query with SQL.
   - Open source [here](https://github.com/shrimalmadhur/trendcaster).


### PR DESCRIPTION
### castalytics
[Castalytics](https://castalytics.farcase.xyz/) doesn't load anymore and redirects to http://net.domain.name/?subid1=farcase.xyz&terms=play%20online%20games,google%20server%20cloud,gmail%20account .

The main website https://farcase.xyz is (I think) suffered from a domain takeover.

---

### casterscan

https://casterscan.com looks like this now, have raised an issue in their repo, https://github.com/dylsteck/casterscan/issues/5. Maybe due to overload of casts, it fails to parse the data from the farcaster protocol hubs.
![image](https://github.com/a16z/awesome-farcaster/assets/72032538/d4bcd13a-f1a3-482c-bf87-83447e4aefd0)
