### PR TITLE
Added composecast.xyz to awesome-farcaster tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@
 - [Fardrop](https://fardrop.xyz) - Create an allowlist based on followers.
 - [Hatecast](https://hatecast.xyz/) - Track who a user unfollows and who unfollows them.
 - [Farcaster.vote](https://farcaster.vote/app) - Verifiable & decentralized polls within Farcaster Frames.
+- [Composecastxyz](https://github.com/0xSemicolon/composecastxyz) - Privacy preserving, MIT licensed compose cast gateway
 
 ## Bots
 


### PR DESCRIPTION
Composecastxyz is a gateway service that solves the problem wherein readonly clients or frames need to prompt a user to compose a cast, and currently all direct requests to https://warpcast.com/~/compose?text=&embeds[]=. Instead developers can either self host composecastxyz easily, directing users to compose.their.domain?text=&embeds[]=, or to https://composecast.xyz?text=&embeds[]=.

There is no backend, any data is stored entirely on the user's device in IndexedDB. Preferences are configurable, so users can opt to post from supercast say even if they're coming from warpcast.