### PR TITLE
add castsense

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ These bots are available on Farcaster. You can mention them in a cast to get a r
 ### Analytics and Data
 
 - [Farcaster User Stats](https://www.farcasteruserstats.com/) - User analytics. - [GitHub](https://github.com/mattwelter/farcaster-user-stats)
+- [CastSense](https://www.castsense.xyz/) - User and channel analytics.
 - [Trendcaster](https://www.trendcaster.xyz) - Personal analytics.
 - [Farcaster Network](https://farcaster.network) - Network dashboard.
 - [Casterscan](https://casterscan.com) - A block explorer for Farcaster.


### PR DESCRIPTION
[CastSense](https://www.castsense.xyz/) is a detailed analytics tool to understand farcaster engagement and followers. works for channels and users