### PR TITLE
Removed Tipcast - not maintained and active anymore.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,6 @@
   - DAO-focused - [Web](https://alphacaster.xyz)
 - [Eventcaster](https://eventcaster.xyz)
   - Meetups & Events - [Web](https://eventcaster.xyz)
-- [TipCast](https://tipcast.xyz)
-  - Tip Casters via Polygon - [Web](https://tipcast.xyz)
 - [SayMore](https://saymore.tv/)
   - Creator Requests - [Web](https://saymore.tv/)
 - [Absorb](https://www.getabsorb.com)


### PR DESCRIPTION
Tipcast isn't active anymore. The domain redirects to a different domain: http://ww25.tipcast.xyz/?subid1=20240620-1703-483e-b855-e419dacbe24f which doesn't work.